### PR TITLE
cd wix-telemetry-appengine (it's not working)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can use this project as a basis for deploying your own adapter.
 - Install Node v10 (currently v10.15.3)
 - Install git
 - `$ git clone https://github.com/wix/corvid-stackdriver-telemetry-adapter.git`
-- `$ cd corvid-stackdriver-telemetry-adapter`
+- `$ cd velo-gcloud-logging`
 - Follow GCP instructions for [creating a google app engine standard environment for node.js](https://cloud.google.com/appengine/docs/standard/nodejs/quickstart).
 - [Set up authentication for a stackdriver client](https://cloud.google.com/logging/docs/reference/libraries) by adding a `service-account-key.json`.
  

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can use this project as a basis for deploying your own adapter.
 - Install Node v10 (currently v10.15.3)
 - Install git
 - `$ git clone https://github.com/wix/corvid-stackdriver-telemetry-adapter.git`
-- `$ cd wix-telemetry-appengine`
+- `$ cd corvid-stackdriver-telemetry-adapter`
 - Follow GCP instructions for [creating a google app engine standard environment for node.js](https://cloud.google.com/appengine/docs/standard/nodejs/quickstart).
 - [Set up authentication for a stackdriver client](https://cloud.google.com/logging/docs/reference/libraries) by adding a `service-account-key.json`.
  

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/wix/corvid-stackdriver-telemetry-adapter"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "files": [
     "app"
@@ -26,14 +26,14 @@
     "deploy": "gcloud app deploy"
   },
   "dependencies": {
-    "@google-cloud/logging": "^4.4.0",
-    "body-parser": "^1.18.3",
-    "express": "^4.16.3"
+    "@google-cloud/logging": "^11.0.0",
+    "body-parser": "^1.20.2",
+    "express": "^4.18.2"
   },
   "devDependencies": {
-    "eslint": "^5.15.2",
-    "eslint-config-google": "^0.12.0",
-    "jest": "^24.0.0",
+    "eslint": "^8.52.0",
+    "eslint-config-google": "^0.14.0",
+    "jest": "^29.7.0",
     "node-fetch": "^2.3.0"
   },
   "cloud-repo-tools": {


### PR DESCRIPTION
Change readme with the new one.

cd wix-telemetry-appengine is not working I was able to use cd corvid-stackdriver-telemetry-adapter.